### PR TITLE
fix: Check if stream can seek during import

### DIFF
--- a/src/VirtoCommerce.ImportModule.CsvHelper/CsvDataReader.cs
+++ b/src/VirtoCommerce.ImportModule.CsvHelper/CsvDataReader.cs
@@ -57,7 +57,10 @@ namespace VirtoCommerce.ImportModule.CsvHelper
             }
 
             var streamPosition = _stream.Position;
-            _stream.Seek(0, SeekOrigin.Begin);
+            if (_stream.CanSeek)
+            {
+                _stream.Seek(0, SeekOrigin.Begin);
+            }
 
             var streamReader = new StreamReader(_stream, leaveOpen: true);
             var csvReader = new CsvReader(streamReader, CsvConfiguration);
@@ -74,7 +77,10 @@ namespace VirtoCommerce.ImportModule.CsvHelper
                 _totalCount++;
             }
 
-            _stream.Seek(streamPosition, SeekOrigin.Begin);
+            if (_stream.CanSeek)
+            {
+                _stream.Seek(streamPosition, SeekOrigin.Begin);
+            }
 
             return _totalCount.Value;
         }


### PR DESCRIPTION
## Description
We have an exception in CsvDataReader if the imported stream does not allow Seek operation
## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Import_3.808.0-pr-34-5d8c.zip