### PR TITLE
fix: MF bundle build fixes and vc-shell upgrade to alpha.28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,6 +338,7 @@ ASALocalRun/
 
 # Webpack/Vite build output
 dist/
+.__mf__temp/
 **/Content/*-app/
 .history
 

--- a/src/VirtoCommerce.ImportModule.Web/App/package.json
+++ b/src/VirtoCommerce.ImportModule.Web/App/package.json
@@ -33,8 +33,8 @@
     "@types/node": "^20.10.5",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
-    "@vc-shell/api-client-generator": "^2.0.0-alpha.11",
-    "@vc-shell/ts-config": "^2.0.0-alpha.11",
+    "@vc-shell/api-client-generator": "2.0.0-alpha.28",
+    "@vc-shell/ts-config": "2.0.0-alpha.28",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/eslint-config-prettier": "^9.0.0",
     "@vue/eslint-config-typescript": "^13.0.0",
@@ -68,9 +68,9 @@
     "@module-federation/dts-plugin": "2.0.1"
   },
   "dependencies": {
-    "@vc-shell/config-generator": "^2.0.0-alpha.11",
-    "@vc-shell/framework": "^2.0.0-alpha.11",
-    "@vc-shell/mf-module": "^2.0.0-alpha.11",
+    "@vc-shell/config-generator": "2.0.0-alpha.28",
+    "@vc-shell/framework": "2.0.0-alpha.28",
+    "@vc-shell/mf-module": "2.0.0-alpha.28",
     "@virtocommerce/import-app": "^1.1.3",
     "@vueuse/core": "^10.7.1",
     "@vueuse/integrations": "^10.7.1",

--- a/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/components/notifications/ImportPushNotification.vue
+++ b/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/components/notifications/ImportPushNotification.vue
@@ -18,37 +18,22 @@
 </template>
 
 <script lang="ts" setup>
-import { useBladeNavigation, NotificationTemplate } from "@vc-shell/framework";
+import { useBladeNavigation, useNotificationContext, NotificationTemplate } from "@vc-shell/framework";
 import { ImportPushNotification } from "@virtocommerce/import-app-api";
 import { computed } from "vue";
 
-export interface Props {
-  notification: ImportPushNotification;
-}
-
-export interface Emits {
-  (event: "notificationClick"): void;
-}
-
-const props = defineProps<Props>();
-
-const emit = defineEmits<Emits>();
-
-defineOptions({
-  inheritAttrs: false,
-  notifyType: "ImportPushNotification",
-});
+const notification = useNotificationContext<ImportPushNotification>();
 
 const { openBlade, resolveBladeByName } = useBladeNavigation();
 
 const notificationStyle = computed(() => {
-  const notification = props.notification;
-  if (notification.finished && !(notification.errors && notification.errors.length)) {
+  const n = notification.value;
+  if (n.finished && !(n.errors && n.errors.length)) {
     return {
       color: 'var(--import-notification-success-color)',
       icon: "material-check_circle",
     };
-  } else if (!(notification.errors && notification.errors.length) && !notification.finished) {
+  } else if (!(n.errors && n.errors.length) && !n.finished) {
     return {
       color: 'var(--import-notification-info-color)',
       icon: "material-info",
@@ -62,20 +47,19 @@ const notificationStyle = computed(() => {
 });
 
 async function onClick() {
-  if (props.notification.notifyType === "ImportPushNotification") {
-    emit("notificationClick");
+  if (notification.value.notifyType === "ImportPushNotification") {
     await openBlade(
       {
         blade: resolveBladeByName("ImportProfileSelector"),
-        param: props.notification.profileId,
+        param: notification.value.profileId,
       },
       true,
     );
     await openBlade({
       blade: resolveBladeByName("ImportProcess"),
-      param: props.notification.profileId,
+      param: notification.value.profileId,
       options: {
-        importJobId: props.notification.jobId,
+        importJobId: notification.value.jobId,
       },
     });
   }

--- a/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/composables/useImport/index.ts
+++ b/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/composables/useImport/index.ts
@@ -169,9 +169,9 @@ export default (): IUseImport => {
   });
 
   function getLongRunning(args?: { id: string }) {
-    const job = notifications.value.find((x: ImportPushNotification) => {
-      return x.profileId === args?.id;
-    }) as ImportPushNotification;
+    const job = notifications.value.find(
+      (x) => (x as ImportPushNotification).profileId === args?.id,
+    ) as ImportPushNotification | undefined;
 
     if (job && !job.finished) {
       updateStatus(job);

--- a/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/composables/useImportProfiles/index.ts
+++ b/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/composables/useImportProfiles/index.ts
@@ -1,14 +1,14 @@
 import { ref, computed, watch, Ref } from "vue";
 import {
   IDataImporter,
+  IObjectSettingEntry,
   ImportClient,
   ImportProfile,
   ISearchImportProfilesCriteria,
+  ObjectSettingEntry,
   SearchImportProfilesCriteria,
 } from "@virtocommerce/import-app-api";
 import {
-  IObjectSettingEntry,
-  ObjectSettingEntry,
   useApiClient,
   useAsync,
   useLoading,

--- a/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/composables/useImportStatus/index.ts
+++ b/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/composables/useImportStatus/index.ts
@@ -63,8 +63,8 @@ export default function useImportStatus({
       if (importProfiles.value && importProfiles.value?.length) {
         const mappedProfiles = importProfiles.value.map((item) => {
           const notification = newNotifications.value.find(
-            (x: ImportPushNotification) => x.profileId === item.id,
-          ) as ImportPushNotification;
+            (x) => (x as ImportPushNotification).profileId === item.id,
+          ) as ImportPushNotification | undefined;
 
           if (notification) {
             item.inProgress = !notification.finished;

--- a/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/pages/import-new.vue
+++ b/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/pages/import-new.vue
@@ -313,8 +313,8 @@ const bladeWidth = ref(70);
 
 watch(
   moduleNotifications,
-  (newVal: ImportPushNotification[]) => {
-    newVal.forEach((message) => {
+  (newVal) => {
+    (newVal as ImportPushNotification[]).forEach((message) => {
       const messageContent = message.profileName ? `${message.profileName}: ${message.title}` : message.title;
 
       if (!importStarted.value && message.profileId === props.param) {

--- a/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/pages/import-new.vue
+++ b/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/pages/import-new.vue
@@ -685,8 +685,8 @@ defineExpose({
   }
 
   &__history {
-    & .vc-card__body {
-      @apply tw-flex tw-flex-col;
+    .vc-table-adapter {
+      @apply tw-basis-auto;
     }
   }
 }

--- a/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/pages/import-process.vue
+++ b/src/VirtoCommerce.ImportModule.Web/App/src/modules/import/pages/import-process.vue
@@ -101,8 +101,8 @@ const importStarted = computed(() => !!(importStatus.value && importStatus.value
 
 watch(
   moduleNotifications,
-  (newVal: ImportPushNotification[]) => {
-    newVal.forEach((message) => {
+  (newVal) => {
+    (newVal as ImportPushNotification[]).forEach((message) => {
       const messageContent = message.profileName ? `${message.profileName} ${message.title}` : message.title;
 
       if (!importStarted.value && message.profileId === props.param) {

--- a/src/VirtoCommerce.ImportModule.Web/App/src/modules/vite.config.with-api.mts
+++ b/src/VirtoCommerce.ImportModule.Web/App/src/modules/vite.config.with-api.mts
@@ -5,6 +5,7 @@ import { getDynamicModuleConfiguration } from "@vc-shell/mf-module";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default getDynamicModuleConfiguration({
+  base: "/apps/import-app/",
   entry: "./src/modules/index.ts",
   compatibility: {
     framework: "^2.0.0",

--- a/src/VirtoCommerce.ImportModule.Web/App/src/modules/vite.config.with-api.mts
+++ b/src/VirtoCommerce.ImportModule.Web/App/src/modules/vite.config.with-api.mts
@@ -1,50 +1,14 @@
 import { resolve, dirname } from "node:path";
-import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { getDynamicModuleConfiguration } from "@vc-shell/mf-module";
-import type { Plugin } from "vite";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-/**
- * Preserve the standalone index.html across the MF build.
- *
- * The standalone build (build:app) produces index.html first, then the MF
- * build (build:modules-bundle) overwrites it with an MF-bootstrapped version
- * that cannot run without a host. This plugin saves the standalone HTML
- * before the build and restores it after all files are written.
- */
-function preserveStandaloneHtml(): Plugin {
-  let savedHtml: Buffer | null = null;
-  const htmlPath = resolve("dist", "index.html");
-
-  return {
-    name: "preserve-standalone-html",
-    buildStart() {
-      try {
-        savedHtml = readFileSync(htmlPath);
-      } catch {
-        savedHtml = null;
-      }
-    },
-    closeBundle() {
-      if (savedHtml) {
-        writeFileSync(htmlPath, savedHtml);
-      }
-    },
-  };
-}
-
 export default getDynamicModuleConfiguration({
-  base: "/apps/import-app/",
   entry: "./src/modules/index.ts",
   compatibility: {
     framework: "^2.0.0",
   },
-  build: {
-    emptyOutDir: false,
-  },
-  plugins: [preserveStandaloneHtml()],
   resolve: {
     alias: {
       "/assets/empty.png": resolve(__dirname, "../../public/assets/empty.png"),

--- a/src/VirtoCommerce.ImportModule.Web/App/src/modules/vite.config.with-api.mts
+++ b/src/VirtoCommerce.ImportModule.Web/App/src/modules/vite.config.with-api.mts
@@ -1,8 +1,39 @@
 import { resolve, dirname } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { getDynamicModuleConfiguration } from "@vc-shell/mf-module";
+import type { Plugin } from "vite";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Preserve the standalone index.html across the MF build.
+ *
+ * The standalone build (build:app) produces index.html first, then the MF
+ * build (build:modules-bundle) overwrites it with an MF-bootstrapped version
+ * that cannot run without a host. This plugin saves the standalone HTML
+ * before the build and restores it after all files are written.
+ */
+function preserveStandaloneHtml(): Plugin {
+  let savedHtml: Buffer | null = null;
+  const htmlPath = resolve("dist", "index.html");
+
+  return {
+    name: "preserve-standalone-html",
+    buildStart() {
+      try {
+        savedHtml = readFileSync(htmlPath);
+      } catch {
+        savedHtml = null;
+      }
+    },
+    closeBundle() {
+      if (savedHtml) {
+        writeFileSync(htmlPath, savedHtml);
+      }
+    },
+  };
+}
 
 export default getDynamicModuleConfiguration({
   base: "/apps/import-app/",
@@ -10,6 +41,10 @@ export default getDynamicModuleConfiguration({
   compatibility: {
     framework: "^2.0.0",
   },
+  build: {
+    emptyOutDir: false,
+  },
+  plugins: [preserveStandaloneHtml()],
   resolve: {
     alias: {
       "/assets/empty.png": resolve(__dirname, "../../public/assets/empty.png"),

--- a/src/VirtoCommerce.ImportModule.Web/App/src/router/routes.ts
+++ b/src/VirtoCommerce.ImportModule.Web/App/src/router/routes.ts
@@ -1,6 +1,5 @@
 import { RouteRecordRaw } from "vue-router";
 import App from "../pages/App.vue";
-import { BladeVNode, useBladeNavigation } from "@vc-shell/framework";
 
 const sellerIdRegex = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
 
@@ -13,28 +12,11 @@ export const routes: RouteRecordRaw[] = [
       root: true,
     },
     children: [],
-    beforeEnter: (to) => {
-      const { sellerId } = to.params;
-
-      if (!sellerId || new RegExp(sellerIdRegex).test(sellerId as string)) {
-        return true;
-      } else {
-        return { path: (to.matched[1].components?.default as BladeVNode).type.url as string };
-      }
-    },
     redirect: (to) => {
       if (to.name === "App") {
         return { path: to.params.sellerId ? to.path + "/import" : "/import", params: to.params };
       }
       return to.path;
-    },
-  },
-  {
-    path: `/:sellerId(${sellerIdRegex})?/:pathMatch(.*)*`,
-    component: App,
-    beforeEnter: async (to) => {
-      const { routeResolver } = useBladeNavigation();
-      return routeResolver(to);
     },
   },
 ];

--- a/src/VirtoCommerce.ImportModule.Web/App/yarn.lock
+++ b/src/VirtoCommerce.ImportModule.Web/App/yarn.lock
@@ -98,6 +98,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.27.0, @babel/parser@npm:^7.29.2":
+  version: 7.29.2
+  resolution: "@babel/parser@npm:7.29.2"
+  dependencies:
+    "@babel/types": "npm:^7.29.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10/45d050bf75aa5194b3255f156173e8553d615ff5a2434674cc4a10cdc7c261931befb8618c996a1c449b87f0ef32a3407879af2ac967d95dc7b4fdbae7037efa
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.27.2":
   version: 7.27.2
   resolution: "@babel/parser@npm:7.27.2"
@@ -3482,9 +3493,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vc-shell/api-client-generator@npm:^2.0.0-alpha.11":
-  version: 2.0.0-alpha.11
-  resolution: "@vc-shell/api-client-generator@npm:2.0.0-alpha.11"
+"@vc-shell/api-client-generator@npm:2.0.0-alpha.28":
+  version: 2.0.0-alpha.28
+  resolution: "@vc-shell/api-client-generator@npm:2.0.0-alpha.28"
   dependencies:
     chalk: "npm:^2.4.2"
     cross-spawn: "npm:^7.0.3"
@@ -3494,27 +3505,29 @@ __metadata:
     vite-plugin-dts: "npm:^3.6.4"
   bin:
     api-client-generator: ./dist/api-client-generator.js
-  checksum: 10/6eb4a025081b7606758785ce0f90e8c86484e56c6663b47f01e4613d80a501cab0f205f2b6521dd8af442e855ef7b8be27735c8c8a6c82cb08c0193af5031f6b
+  checksum: 10/1edd8d364e7c5ad714f3ca85a7e045f0d1a42dcb4fbd5c9feaeedd08bf83f4c80be91ba40d7143d20cbb0c99a18ff118e7e079f7e255e7affd9eae6e5ef51352
   languageName: node
   linkType: hard
 
-"@vc-shell/config-generator@npm:^2.0.0-alpha.11":
-  version: 2.0.0-alpha.11
-  resolution: "@vc-shell/config-generator@npm:2.0.0-alpha.11"
+"@vc-shell/config-generator@npm:2.0.0-alpha.28":
+  version: 2.0.0-alpha.28
+  resolution: "@vc-shell/config-generator@npm:2.0.0-alpha.28"
   dependencies:
+    "@babel/parser": "npm:^7.27.0"
     "@vitejs/plugin-vue": "npm:^5.2.3"
+    "@vue/compiler-sfc": "npm:^3.5.30"
     vite: "npm:^6.3.3"
     vite-plugin-checker: "npm:^0.9.1"
     vite-plugin-circular-dependency: "npm:^0.5.0"
     vite-plugin-mkcert: "npm:^1.17.1"
     vue: "npm:^3.5.30"
-  checksum: 10/4abf67e2d4864af01ea67da44328fecff992e9fcfb883148349184e1bb3a445a5450bd5107f7756963b828c2a932d7025c89a7c868761284541033b551a34411
+  checksum: 10/5de7b649d17373a4b22607976abb82cd0f723bc176ba8b8168eb5ae06cdce94fe06dfa7192f0aad59a01b70bebfbe047d0d3e7e29025d10f7dd8d5e241ff9b6e
   languageName: node
   linkType: hard
 
-"@vc-shell/framework@npm:^2.0.0-alpha.11":
-  version: 2.0.0-alpha.11
-  resolution: "@vc-shell/framework@npm:2.0.0-alpha.11"
+"@vc-shell/framework@npm:2.0.0-alpha.28":
+  version: 2.0.0-alpha.28
+  resolution: "@vc-shell/framework@npm:2.0.0-alpha.28"
   dependencies:
     "@floating-ui/dom": "npm:^1.7.4"
     "@floating-ui/vue": "npm:^1.0.6"
@@ -3553,6 +3566,7 @@ __metadata:
     dompurify: "npm:^3.0.11"
     gridstack: "npm:^12.4.2"
     iso-639-1: "npm:^3.1.0"
+    lodash-es: "npm:^4.17.21"
     lucide-vue-next: "npm:^0.577.0"
     normalize.css: "npm:^8.0.1"
     semver: "npm:^7.7.4"
@@ -3574,34 +3588,37 @@ __metadata:
       optional: false
     vue-router:
       optional: false
-  checksum: 10/f6b16009bdd355c4dd4940cef920876ff954d93fcc73278cdbf7750b36089d734d849e3523940461d5cbcbe9137bdc58dc0a296e639a7e6f65482abe1c5205ed
+  bin:
+    vc-check-locales: ./dist/scripts/check-locales.cjs
+  checksum: 10/dd0466bb8f18625c661093e30de92aad163956bae3c1eea7a06bca95432cd6b2728f880be8dc387d0187adefe2f85129d71049872631680c227b3d039e812203
   languageName: node
   linkType: hard
 
-"@vc-shell/mf-config@npm:2.0.0-alpha.11":
-  version: 2.0.0-alpha.11
-  resolution: "@vc-shell/mf-config@npm:2.0.0-alpha.11"
-  checksum: 10/8702a43d5957f43224679ec72ec8f4a553d47946bbceecf6f6c9d2a7d71c789ae44e5bc1914fa4fe0fc9046bf66bedbfa6d6318405f03b1d255dbeb6371e3223
+"@vc-shell/mf-config@npm:2.0.0-alpha.28":
+  version: 2.0.0-alpha.28
+  resolution: "@vc-shell/mf-config@npm:2.0.0-alpha.28"
+  checksum: 10/513649a00f0b425b7bd23de1af3d5530507352ac96f5b27643ecbd197581c9ca233c6eb24f466057f1bb918b1ccbba3fdd5360df02da4e90e115df937932cb06
   languageName: node
   linkType: hard
 
-"@vc-shell/mf-module@npm:^2.0.0-alpha.11":
-  version: 2.0.0-alpha.11
-  resolution: "@vc-shell/mf-module@npm:2.0.0-alpha.11"
+"@vc-shell/mf-module@npm:2.0.0-alpha.28":
+  version: 2.0.0-alpha.28
+  resolution: "@vc-shell/mf-module@npm:2.0.0-alpha.28"
   dependencies:
     "@module-federation/vite": "npm:^1.12.2"
-    "@vc-shell/mf-config": "npm:2.0.0-alpha.11"
+    "@vc-shell/mf-config": "npm:2.0.0-alpha.28"
   peerDependencies:
+    "@vc-shell/config-generator": ^2.0.0-alpha.28
     "@vitejs/plugin-vue": ^5.0.0
     vite: ^5.0.0 || ^6.0.0
-  checksum: 10/3d9859a667b84d70c566f4ffbc9e3b412b102baaf3293508d6a196324ebe99691bce00989a8ed7d14d1abb5cfbf395a732d5099b56176201c4f6e6b683754524
+  checksum: 10/5bb24aa8c73a673b4b6e20c28c163279c51a9da5c71ae9e03e8b622cfb37ba5732b8a864d50c4c3a5217901d7c64be177fb51425f9cadf3303719dfdc3cdcbb5
   languageName: node
   linkType: hard
 
-"@vc-shell/ts-config@npm:^2.0.0-alpha.11":
-  version: 2.0.0-alpha.11
-  resolution: "@vc-shell/ts-config@npm:2.0.0-alpha.11"
-  checksum: 10/c99f34e64b58eadef094be45feaa06f727c74c61237ae3764111592e53a48c55b9327d66a12b28b33d00a4777d398cf0ef05c4a52b22ed853dde2c623317197c
+"@vc-shell/ts-config@npm:2.0.0-alpha.28":
+  version: 2.0.0-alpha.28
+  resolution: "@vc-shell/ts-config@npm:2.0.0-alpha.28"
+  checksum: 10/3b10a71ab0c1532df796e42cd0c9d850082ee3eec8a1a6e49aeb7935b805755eb5c214a333752b46bddc78b45a23e3f8d7c6f89ff4814cba53ed833b09b351a0
   languageName: node
   linkType: hard
 
@@ -3780,6 +3797,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-core@npm:3.5.31":
+  version: 3.5.31
+  resolution: "@vue/compiler-core@npm:3.5.31"
+  dependencies:
+    "@babel/parser": "npm:^7.29.2"
+    "@vue/shared": "npm:3.5.31"
+    entities: "npm:^7.0.1"
+    estree-walker: "npm:^2.0.2"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10/a4c0ff23f94adee76c49d07f8573151325b7ade5ebb22370195d120607c568e4228de63c18a1f72688a21ae4bcbb0bdf3e546ca35f672dcd019fa2742b7fc2dc
+  languageName: node
+  linkType: hard
+
 "@vue/compiler-dom@npm:3.5.30":
   version: 3.5.30
   resolution: "@vue/compiler-dom@npm:3.5.30"
@@ -3787,6 +3817,16 @@ __metadata:
     "@vue/compiler-core": "npm:3.5.30"
     "@vue/shared": "npm:3.5.30"
   checksum: 10/f15f261a53c97e745931506c5b68839edd8371cb1311512e7e208fed9bf69109d7f50cbad14e1a7d19141efbc7d298b3a18740c84fb7959fc61bfd97794a27e8
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-dom@npm:3.5.31":
+  version: 3.5.31
+  resolution: "@vue/compiler-dom@npm:3.5.31"
+  dependencies:
+    "@vue/compiler-core": "npm:3.5.31"
+    "@vue/shared": "npm:3.5.31"
+  checksum: 10/12b90bec203ccbbed362575da9c0b76a2f643d4790394e4093bf35969bebe83f669ac39d045ea501e45908f00fb444f6cc79b44dd6bae7e62956c6c7997f87d3
   languageName: node
   linkType: hard
 
@@ -3817,6 +3857,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-sfc@npm:^3.5.30":
+  version: 3.5.31
+  resolution: "@vue/compiler-sfc@npm:3.5.31"
+  dependencies:
+    "@babel/parser": "npm:^7.29.2"
+    "@vue/compiler-core": "npm:3.5.31"
+    "@vue/compiler-dom": "npm:3.5.31"
+    "@vue/compiler-ssr": "npm:3.5.31"
+    "@vue/shared": "npm:3.5.31"
+    estree-walker: "npm:^2.0.2"
+    magic-string: "npm:^0.30.21"
+    postcss: "npm:^8.5.8"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10/5a8b1b612b6ff35334bdcab1a90a986106805b063f4352a57fc3e32b95ebb00cbb26fb722ce82c2e7121e165003498b6b577cc0ff56bba30cf70cf674d48a425
+  languageName: node
+  linkType: hard
+
 "@vue/compiler-ssr@npm:3.5.30":
   version: 3.5.30
   resolution: "@vue/compiler-ssr@npm:3.5.30"
@@ -3824,6 +3881,16 @@ __metadata:
     "@vue/compiler-dom": "npm:3.5.30"
     "@vue/shared": "npm:3.5.30"
   checksum: 10/85d9e8093659e789abe3b708b9597ab54015f07e348331b303d50d907b5a8f24e40ca9664686f042a34f9d281e7feded480b50c3d0f3169aeb4f977b63b2d15f
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-ssr@npm:3.5.31":
+  version: 3.5.31
+  resolution: "@vue/compiler-ssr@npm:3.5.31"
+  dependencies:
+    "@vue/compiler-dom": "npm:3.5.31"
+    "@vue/shared": "npm:3.5.31"
+  checksum: 10/f7f7968cbf5b2cd32170f68e483410bff1d37f96e6dad3a9cac07d594945a0dd3e2ecf39cccd45a47cdf0f2570594863cc1dff49ec353def6bd38a90ec3a491c
   languageName: node
   linkType: hard
 
@@ -4005,6 +4072,13 @@ __metadata:
   version: 3.5.30
   resolution: "@vue/shared@npm:3.5.30"
   checksum: 10/4c92bc0de3a227df03f76e9346f23030809a22b16150c6eff0a28fbb890d012dcb7724d652fa583b45b4ea16192f9409cdeb80b3ee41af4680e04e287d94cfd3
+  languageName: node
+  linkType: hard
+
+"@vue/shared@npm:3.5.31":
+  version: 3.5.31
+  resolution: "@vue/shared@npm:3.5.31"
+  checksum: 10/d15ca5ad64da5c599a9cef5105b8af1c652d99062172723dfca77a520dce861f33bcc01e188f9ad7c8e78b136b636c1d7c8104ad0c4715c93edd6024162e5f30
   languageName: node
   linkType: hard
 
@@ -7742,11 +7816,11 @@ __metadata:
     "@types/node": "npm:^20.10.5"
     "@typescript-eslint/eslint-plugin": "npm:^7.4.0"
     "@typescript-eslint/parser": "npm:^7.4.0"
-    "@vc-shell/api-client-generator": "npm:^2.0.0-alpha.11"
-    "@vc-shell/config-generator": "npm:^2.0.0-alpha.11"
-    "@vc-shell/framework": "npm:^2.0.0-alpha.11"
-    "@vc-shell/mf-module": "npm:^2.0.0-alpha.11"
-    "@vc-shell/ts-config": "npm:^2.0.0-alpha.11"
+    "@vc-shell/api-client-generator": "npm:2.0.0-alpha.28"
+    "@vc-shell/config-generator": "npm:2.0.0-alpha.28"
+    "@vc-shell/framework": "npm:2.0.0-alpha.28"
+    "@vc-shell/mf-module": "npm:2.0.0-alpha.28"
+    "@vc-shell/ts-config": "npm:2.0.0-alpha.28"
     "@virtocommerce/import-app": "npm:^1.1.3"
     "@vitejs/plugin-vue": "npm:^5.2.3"
     "@vue/eslint-config-prettier": "npm:^9.0.0"


### PR DESCRIPTION
## Summary

Fixes frontend issues introduced by the vc-shell 1.x → 2.x migration:
- Module assets returning 404 (wrong base path)
- "Shared module must be provided by host" error (standalone HTML overwritten by MF build)
- Blank screen / no blade content (v1 route resolver blocking v2 BladeNavigationPlugin)
- "Last executions" table empty (VcTableAdapter CSS collapse)
- TypeError on notification bell click (notification template API change)

## Changes

### vc-shell upgrade (alpha.11 → alpha.28)
- Update all `@vc-shell/*` packages to `2.0.0-alpha.28`
- Alpha.28 includes 180+ commits of fixes: VcTable rendering, notification reactivity, permissions, markRaw for components
- Alpha.28 builds MF output to `dist/mf/` and auto-derives `base` from `package.json` name — no workarounds needed

### Notification template migration (vc-shell v2)
- Replace `defineProps<{ notification }>` with `useNotificationContext<ImportPushNotification>()` composable — vc-shell v2 delivers notification data via provide/inject, not props
- Remove `defineOptions({ inheritAttrs: false, notifyType })` and `defineEmits`

### VcTableAdapter CSS fix
- Override `flex-basis: 0` → `auto` on `.vc-table-adapter` inside the history card — the adapter's `flex-basis: 0` collapses to zero height in auto-sized VcCard containers

### Route fix (v1 → v2)
- Remove catch-all route with `routeResolver` that preempted v2 `BladeNavigationPlugin`

### TypeScript compatibility
- Move `ObjectSettingEntry`/`IObjectSettingEntry` imports from `@vc-shell/framework` to `@virtocommerce/import-app-api` (framework changed from class to interface)
- Fix `PushNotification` type casts for framework interface compatibility

### Misc
- Add `.__mf__temp/` to `.gitignore` (MF build cache)

## Test plan
- [x] Import app loads at `/apps/import-app/` without 404 errors
- [x] Blades open correctly (import profiles list, new import, profile details)
- [x] "Last executions" table renders data
- [x] Import start triggers notifications
- [x] Notification bell click opens import details without TypeError
- [ ] MF remote loads correctly from vc-shell host

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Import_3.809.0-pr-40-1e89.zip